### PR TITLE
Improved error messages

### DIFF
--- a/dispatch.js
+++ b/dispatch.js
@@ -117,7 +117,6 @@ const ACTIONS = {
         } catch (e) {
           console.log(e);
           state.error = true;
-          console.log(e.stack, 'stack', e.message, 'message')
           let split = e.stack.split('\n').slice(0, 2);
           function filterInts (str) {
             return str.split('').filter(char => char == +char).join('');
@@ -134,10 +133,10 @@ const ACTIONS = {
           if (checkLine(split[lineNumber])) {
             let trace = split[lineNumber].split(':')[split[lineNumber].split(':').length - 2] + ':' + split[lineNumber].split(':')[split[lineNumber].split(':').length - 1]
             let [line, col] = trace.split(':');
-            const str = `${e.stack.includes(e.message) ? split[0] : 'RuntimeError: ' + e.message}\n    at code.js:${+filterInts(line) - 2}:${+filterInts(col)}`;
+            const str = `${e.stack.includes(e.message) ? split[0] : (e.name ? e.name : 'RuntimeError') + ': ' + e.message}\n    at code.js:${+filterInts(line) - 2}:${+filterInts(col)}`;
             state.logs.push(str);
           }
-          else state.logs.push(e.stack);
+          else state.logs.push(e.stack.includes(e.message) ? (e.name ? e.name : 'RuntimeError') : (e.name ? e.name : 'RuntimeError') + ': ' + e.message); // Best(?) combination of checking if certain error properties exist
         }
       } else {
         state.error = true;

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="./styles/button.css"></link>
   <link rel="stylesheet" href="./styles/cursors.css"></link>
   <script defer data-domain="hackclub.com" src="https://plausible.io/js/plausible.js"></script>
+  <script src="https://unpkg.com/esprima@~4.0/dist/esprima.js"></script>
 <!--   <script
     src="https://js.sentry-cdn.com/904e4267a16d4344a22f5e1c543e5b0a.min.js"
     crossorigin="anonymous"

--- a/utils/validate.js
+++ b/utils/validate.js
@@ -8,7 +8,7 @@ export default function validate (code) {
         let colsBefore = code.split('\n').slice(0, err.lineNumber - 1).join('\n').length;
         error = {
             line: err.lineNumber,
-            col: err.index - colsBefore,
+            col: err.lineNumber == 1 ? err.index - colsBefore + 1 : err.index - colsBefore,
             message: err.description
         }
     }

--- a/utils/validate.js
+++ b/utils/validate.js
@@ -1,0 +1,20 @@
+export default function validate (code) {
+    let error;
+    let success = true;
+    try {
+        esprima.parse(code, { tolerant: true, loc: true });
+    } catch (err) {
+        success = false;
+        let colsBefore = code.split('\n').slice(0, err.lineNumber - 1).join('\n').length;
+        error = {
+            line: err.lineNumber,
+            col: err.index - colsBefore,
+            message: err.description
+        }
+    }
+    return {
+        error,
+        success,
+        code
+    };
+}


### PR DESCRIPTION
This includes improved error messages by stripping down the browser-given error message to only two things:
1. the stack trace (inside of the editor, not dispatch.js or any other gamelab files)
2. the type of error or message given by the browser.

This also adds the esprima library to check for errors ahead of time because the browser does not give you a stack trace for syntax errors. (Only runtime errors.)
This has been tested on the latest version of Chrome, and works fine. Fixes are needed for Firefox and Safari.

See #14 

Firefox: 
![image](https://user-images.githubusercontent.com/76178582/151924809-38900647-5693-4c21-94ca-1da88cb76a54.png)

Safari:
![image](https://user-images.githubusercontent.com/76178582/151924834-ed012f97-6fee-402d-8f7b-a267288156dd.png)
